### PR TITLE
Make unable-to-deploy a hard fail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,29 +21,11 @@ jobs:
       - name: Install Packages
         run: npm ci
 
-      - name: Check for Deployment Target
-        id: check_vars
-        shell: bash
-        run: |
-          unset HAS_REGISTRY_DATA
-          if [ ! -z $DOCKER_REGISTRY -a ! -z $DOCKER_USERNAME -a ! -z $DOCKER_PASSWORD ]; then HAS_REGISTRY_DATA='true' ; fi
-          echo ::set-output name=HAS_REGISTRY_DATA::${HAS_REGISTRY_DATA}
-
-          unset HAS_UPDATE_URL
-          if [ ! -z $UPDATE_URL ]; then HAS_UPDATE_URL='true' ; fi
-          echo ::set-output name=HAS_UPDATE_URL::${HAS_UPDATE_URL}
-        env:
-          DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY }}"
-          DOCKER_USERNAME: "${{ secrets.DOCKER_USERNAME }}"
-          DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
-          UPDATE_URL: "${{ secrets.UPDATE_URL }}"
-
       - name: Build
         run: npm run build
 
       - name: Build and Deploy to Docker Registry
         uses: mr-smithers-excellent/docker-build-push@v2
-        if: steps.check_vars.outputs.HAS_REGISTRY_DATA
         with:
           image: wwes/h2p
           tag: latest
@@ -53,8 +35,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Call update webhook
-        if: steps.check_vars.outputs.HAS_UPDATE_URL
-        uses: joelwmale/webhook-action@master
+        uses: joelwmale/webhook-action@1.0.0
         env:
           WEBHOOK_URL: ${{ secrets.UPDATE_URL }}
           data: "{'commit': '${{ github.sha }}'}"


### PR DESCRIPTION
No longer skip deployment steps just because we don't have the secrets in place, that way if the secrets ever vanish from the repo we'll know because the action will fail on push.

This also removes the weird-looking check_vars step and locks us to a specific known-working version of the webhook action.